### PR TITLE
Fix alpha weirdness in ico file when not 256 colours

### DIFF
--- a/webicon.sh
+++ b/webicon.sh
@@ -108,7 +108,7 @@ $PWD/$IMAGE_NAME-16.png \
 $PWD/$IMAGE_NAME-32.png \
 $PWD/$IMAGE_NAME-48.png \
 $PWD/$IMAGE_NAME-64.png \
--colors 256 -background $TRANSPARENT_COLOUR $PWD/$IMAGE_NAME.ico
+-background $TRANSPARENT_COLOUR $PWD/$IMAGE_NAME.ico
 
 ######################################
 # OUTPUT USEFUL MARKUP


### PR DESCRIPTION
Addresses #1 by removing the 256 colours setting. I have no idea what effect this will have on the existing output of other images.
